### PR TITLE
workaround jdk26 on el7 missing /lib64/libm.so.6

### DIFF
--- a/999_cleanAll.sh
+++ b/999_cleanAll.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source "$SCRIPT_DIR/testlib.bash"
+
+parseArguments "$@"
+processArguments
+setup
+# always clean at the end, disable for debug
+CLEAN_IMAGES=true cleanImages
+

--- a/testlib.bash
+++ b/testlib.bash
@@ -176,7 +176,7 @@ function runImageInPodman() {
 FROM $os
 RUN  whoami
 EOF
-if echo "$os" | grep -e "centos:7" ; then
+  if echo "$os" | grep -e "centos:7" ; then
     cat <<EOF >> $podmanfile
 RUN  sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
 RUN  if \[ "$(uname -m)" = "aarch64" \]; then \\  
@@ -191,8 +191,8 @@ RUN  if \[ "$(uname -m)" = "aarch64" \]; then \\
      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \\  
    fi
 EOF
-fi
-    cat <<EOF >> $podmanfile
+  fi
+  cat <<EOF >> $podmanfile
 RUN  if dnf install -y sudo ; then echo "dnf did"; elif yum install -y sudo ; then echo "yum did"; else echo "both yum and dnf failed"; fi || true
 RUN  if sudo dnf install -y /usr/bin/ps ; then echo "dnf did"; elif sudo yum install -y /usr/bin/ps ; then echo "yum did"; else echo "both yum and dnf failed"; fi  || true
 RUN  if sudo dnf install -y $DEPS ; then echo "dnf did"; elif sudo yum install -y $DEPS ; then echo "yum did"; else echo "both yum and dnf failed"; fi
@@ -202,9 +202,29 @@ RUN  ps -A | head -n 10
 RUN  sudo cat     /etc/passwd.lock  /etc/shadow.lock /etc/group.lock /etc/gshadow.lock "/etc/passwd.*"  "/etc/shadow.*" "/etc/group.*" "/etc/gshadow.*"|| true
 RUN  sudo rm -rvf /etc/passwd.lock  /etc/shadow.lock /etc/group.lock /etc/gshadow.lock "/etc/passwd.*"  "/etc/shadow.*" "/etc/group.*" "/etc/gshadow.*"|| true
 RUN  ps -A | head -n 10
+EOF
+  local WORKAROUND_MISSING_LIB64="true" # todo, decide when and if to fixc
+  if [ $WORKAROUND_MISSING_LIB64 == "true" ] ; then
+    for lib in libm.so.6 ; do
+      cat <<EOF >> $podmanfile
+RUN if [ -e /lib/$lib ] ; then \
+      echo "lib variant of $lib exists"; \
+      if [ -e /lib64/$lib ] ; then \
+        echo "lib64 variant of $lib exists"; \
+      else \
+        echo "lib64 variant of $lib do NOT  exists. Creatig."; \
+        ln -sv /lib/$lib /lib64/$lib ; \
+      fi ; \
+    else \
+     echo "lib variant of $lib do NOT  exists" ; \
+   fi
+EOF
+    done
+  fi
+  cat <<EOF >> $podmanfile
 RUN  a=0; sudo useradd tester || a=\$? ; if [ \$a -eq 0 ] ; then echo "as tester" && su tester -c "DISPLAY=:0 /$jlinkimage/bin/java -m $module" ; else echo "as \$(whoami)" && bash -c "DISPLAY=:0 /$jlinkimage/bin/java -m $module" ; fi
 EOF
-    podman build --network host -f $podmanfile
+  podman build --network host -f $podmanfile
 }
 
 

--- a/testlib.bash
+++ b/testlib.bash
@@ -207,7 +207,7 @@ RUN  if \[ "$(uname -m)" = "aarch64" \]; then \\
      echo "Running on arm64 architecture"; \\  
      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \\  
    elif \[ "$(uname -m)" = "ppc64le" \]; then \\  
-     echo "Running on ppc64le architecture"; \\  
+	     echo "Running on ppc64le architecture"; \\  
      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \\  
    else \\  
      # Default To x64; \\  
@@ -235,14 +235,12 @@ RUN  if sudo dnf install -y glibc ; then echo "dnf did"; elif sudo yum install -
 EOF
   fi
   cat <<EOF >> $podmanfile
-RUN cat <<END > /runit.bash
-cat /runit.bash
-whoami
-getenforce|| true
-if cat /etc/passwd | grep "tester:"  ; then echo "as tester" && su tester -c "DISPLAY=:0 /$jlinkimage/bin/java -m $module" ; else echo "as \\\$(whoami)" && bash -c "DISPLAY=:0 /$jlinkimage/bin/java -m $module" ; fi
-END
+RUN echo cat /runit.bash > /runit.bash
+RUN echo whoami >> /runit.bash
+RUN echo getenforce|| true >> /runit.bash
+RUN echo "if cat /etc/passwd | grep \"tester:\"  ; then echo \"as tester\" && su tester -c \"DISPLAY=:0 /$jlinkimage/bin/java -m $module\" ; else echo \"as \\\$(whoami)\" && bash -c \"DISPLAY=:0 /$jlinkimage/bin/java -m $module\" ; fi" >> /runit.bash
 EOF
-  local tagname=$(echo $os-$jlinkimage-$module| sed 's/[^a-zA-Z0-9]/_/g' )-jlinktests:$(date +%s)
+  local tagname=$(echo $os-$jlinkimage-$module | sed 's/.*/\L&/' | sed 's/[^a-zA-Z0-9]/_/g' )-jlinktests:$(date +%s)
   podman build $secOps --tag $tagname --network host -f $podmanfile
   # conisder adding --security-opt seccomp=unconfined  --cap-add=SYS_ADMIN  to run to prevent 
   # error while loading shared libraries: /lib64/libc.so.6: cannot apply additional memory protection after relocation: Permission denied


### PR DESCRIPTION
todo: decide whether to applly this at all
and if so then (jdk26+el7 container only?)
Build origin only fedora, or also devkit based?

```
as tester
Error: dl failure on line 532
Error: failed /hell/lib/server/libjvm.so, because /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /hell/lib/server/libjvm.so) Error: building at STEP "RUN a=0; sudo useradd tester || a=$? ; if [ $a -eq 0 ] ; then echo "as tester" && su tester -c "DISPLAY=:0 /hell/bin/java -m helloworld" ; else echo "as $(whoami)" && bash -c "DISPLAY=:0 /hell/bin/java -m helloworld" ; fi": while running runtime: exit status 6
```